### PR TITLE
Fix typo in /src/lib/prompts.ts (conservation -> conversation)

### DIFF
--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -17,7 +17,7 @@ export const englishTranslatorAndImprover = (instance: ChatGPTAPI) => {
 };
 
 export const positionInterviewer = (instance: ChatGPTAPI) => {
-  const prompt = `I want you to act as an interviewer. I will be the candidate and you will ask me the interview questions for the \`position\` position. I want you to only reply as the interviewer. Do not write all the conservation at once. I want you to only do the interview with me. Ask me the questions and wait for my answers. Do not write explanations. Ask me the questions one by one like an interviewer does and wait for my answers. My first sentence is "Hi"`;
+  const prompt = `I want you to act as an interviewer. I will be the candidate and you will ask me the interview questions for the \`position\` position. I want you to only reply as the interviewer. Do not write all the conversation at once. I want you to only do the interview with me. Ask me the questions and wait for my answers. Do not write explanations. Ask me the questions one by one like an interviewer does and wait for my answers. My first sentence is "Hi"`;
   return {
     positionInterviewer: async (message: string): Promise<ChatMessage> =>
       createPromptFactory(instance, prompt)(message),


### PR DESCRIPTION
In the prompt "positionInterviewer", there is a typo:

The sentence:

"Do not write all the conservation at once."

Should most likely be:

"Do not write all the conversation at once."